### PR TITLE
Feature/add cancel modal

### DIFF
--- a/src/components/Button/index.css
+++ b/src/components/Button/index.css
@@ -44,6 +44,12 @@ button {
   border: 1px solid var(--button-color-blue);
 }
 
+.button-primary:disabled,
+.button-primary-outline:disabled {
+  cursor: not-allowed;
+  opacity: 0.65;
+}
+
 .button-danger {
   background-color: var(--button-color-red);
   color: var(--white-color);
@@ -64,6 +70,12 @@ button {
   background-color: var(--button-color-red);
   color: var(--white-color);
   border: 1px solid var(--button-color-red);
+}
+
+.button-danger:disabled,
+.button-danger-outline:disabled {
+  cursor: not-allowed;
+  opacity: 0.65;
 }
 
 .button-success {
@@ -88,6 +100,12 @@ button {
   border: 1px solid var(--button-color-green);
 }
 
+.button-success:disabled,
+.button-success-outline:disabled {
+  cursor: not-allowed;
+  opacity: 0.65;
+}
+
 .button-secondary {
   background-color: var(--button-color-gray);
   color: var(--white-color);
@@ -108,4 +126,10 @@ button {
   background-color: var(--button-color-gray);
   color: var(--white-color);
   border: 1px solid var(--button-color-gray);
+}
+
+.button-secondary:disabled,
+.button-secondary-outline:disabled {
+  cursor: not-allowed;
+  opacity: 0.65;
 }

--- a/src/components/Button/index.css
+++ b/src/components/Button/index.css
@@ -1,0 +1,111 @@
+:root {
+  --button-color-blue: #0d6efd;
+  --button-hover-color-blue: #0b5ed7;
+  --button-color-red: #dc3545;
+  --button-hover-color-red: #bb2d3b;
+  --button-color-green: #198754;
+  --button-hover-color-green: #157347;
+  --button-color-gray: #6c757d;
+  --button-hover-color-gray: #5c636a;
+
+  --white-color: #fff;
+  --black-color: #000;
+}
+
+button {
+  font-weight: 400;
+  font-size: 16px;
+  border: none;
+  padding: 10px 20px;
+  border-radius: 5px;
+  cursor: pointer;
+  transition: all 0.3s ease;
+}
+
+.button-primary {
+  background-color: var(--button-color-blue);
+  color: var(--white-color);
+}
+
+.button-primary:hover {
+  background-color: var(--button-hover-color-blue);
+  color: var(--white-color);
+}
+
+.button-primary-outline {
+  background-color: transparent;
+  color: var(--button-color-blue);
+  border: 1px solid var(--button-color-blue);
+}
+
+.button-primary-outline:hover {
+  background-color: var(--button-color-blue);
+  color: var(--white-color);
+  border: 1px solid var(--button-color-blue);
+}
+
+.button-danger {
+  background-color: var(--button-color-red);
+  color: var(--white-color);
+}
+
+.button-danger:hover {
+  background-color: var(--button-hover-color-red);
+  color: var(--white-color);
+}
+
+.button-danger-outline {
+  background-color: transparent;
+  color: var(--button-color-red);
+  border: 1px solid var(--button-color-red);
+}
+
+.button-danger-outline:hover {
+  background-color: var(--button-color-red);
+  color: var(--white-color);
+  border: 1px solid var(--button-color-red);
+}
+
+.button-success {
+  background-color: var(--button-color-green);
+  color: var(--white-color);
+}
+
+.button-success:hover {
+  background-color: var(--button-hover-color-green);
+  color: var(--white-color);
+}
+
+.button-success-outline {
+  background-color: transparent;
+  color: var(--button-color-green);
+  border: 1px solid var(--button-color-green);
+}
+
+.button-success-outline:hover {
+  background-color: var(--button-color-green);
+  color: var(--white-color);
+  border: 1px solid var(--button-color-green);
+}
+
+.button-secondary {
+  background-color: var(--button-color-gray);
+  color: var(--white-color);
+}
+
+.button-secondary:hover {
+  background-color: var(--button-hover-color-gray);
+  color: var(--white-color);
+}
+
+.button-secondary-outline {
+  background-color: transparent;
+  color: var(--button-color-gray);
+  border: 1px solid var(--button-color-gray);
+}
+
+.button-secondary-outline:hover {
+  background-color: var(--button-color-gray);
+  color: var(--white-color);
+  border: 1px solid var(--button-color-gray);
+}

--- a/src/components/Button/index.jsx
+++ b/src/components/Button/index.jsx
@@ -1,0 +1,11 @@
+import './index.css';
+
+const Button = ({ text, onClick, type = 'primary' }) => {
+  return (
+    <button onClick={onClick} className={`button-${type}`}>
+      {text}
+    </button>
+  )
+}
+
+export default Button

--- a/src/components/Button/index.jsx
+++ b/src/components/Button/index.jsx
@@ -1,8 +1,8 @@
 import './index.css';
 
-const Button = ({ text, onClick, type = 'primary' }) => {
+const Button = ({ text, onClick, type = 'primary', disabled = false }) => {
   return (
-    <button onClick={onClick} className={`button-${type}`}>
+    <button onClick={onClick} className={`button-${type}`} disabled={disabled}>
       {text}
     </button>
   )

--- a/src/components/Dialog/index.css
+++ b/src/components/Dialog/index.css
@@ -1,0 +1,43 @@
+.dialog-container {
+    width: 100%;
+    min-height: 100px;
+    padding: 10px;
+    margin-top: 10px;
+    border-radius: 4px;
+    border: 1px solid #ccc;
+    box-sizing: border-box;
+    resize: vertical;
+}
+
+.dialog-container .dialog-title {
+    font-weight: 600;
+    font-size: 20px;
+    color: #000;
+}
+
+.dialog-container .dialog-description {
+    font-weight: 400;
+    font-size: 16px;
+    color: #000;
+}
+
+.dialog-container textarea {
+    width: 100%;
+    min-height: 100px;
+    padding: 10px;
+    margin-top: 10px;
+    border-radius: 4px;
+    border: 1px solid #ccc;
+    box-sizing: border-box;
+    resize: vertical;
+
+    font-family: inherit;
+    font-size: 16px;
+}
+
+.dialog-container .dialog-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 10px;
+    padding: 0px 24px 20px 24px;
+}

--- a/src/components/Dialog/index.css
+++ b/src/components/Dialog/index.css
@@ -21,6 +21,14 @@
     color: #000;
 }
 
+.dialog-container .dialog-loading {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    margin: 20px 0;
+}
+
+
 .dialog-container textarea {
     width: 100%;
     min-height: 100px;

--- a/src/components/Dialog/index.jsx
+++ b/src/components/Dialog/index.jsx
@@ -1,0 +1,46 @@
+import './index.css';
+import { Dialog as MuiDialog, DialogActions, DialogContent, DialogContentText, DialogTitle } from '@mui/material';
+import Button from '../Button';
+
+const Dialog = ({
+  open,
+  onClose,
+  title,
+  description,
+  children,
+  onConfirm,
+  confirm = { message: "Confirmar", type: "primary" },
+  cancel = { message: "Cancelar", type: "secondary" }
+}) => {
+  return (
+    <MuiDialog
+      open={open}
+      onClose={onClose}
+      aria-labelledby="dialog-title"
+      aria-describedby="dialog-description"
+      fullWidth
+      maxWidth="md"
+      className="dialog-container"
+    >
+      {title && (
+        <DialogTitle className="dialog-title">
+          {title}
+        </DialogTitle>
+      )}
+      <DialogContent>
+        {description && (
+          <DialogContentText className="dialog-description" sx={{ mb: 2 }}>
+            {description}
+          </DialogContentText>
+        )}
+        {children}
+      </DialogContent>
+      <DialogActions className="dialog-actions">
+        <Button onClick={onClose} type={cancel.type} text={cancel.message} />
+        <Button onClick={onConfirm} type={confirm.type} text={confirm.message} />
+      </DialogActions>
+    </MuiDialog>
+  )
+}
+
+export default Dialog;

--- a/src/components/Dialog/index.jsx
+++ b/src/components/Dialog/index.jsx
@@ -9,8 +9,9 @@ const Dialog = ({
   description,
   children,
   onConfirm,
-  confirm = { message: "Confirmar", type: "primary" },
-  cancel = { message: "Cancelar", type: "secondary" }
+  confirm = { message: "Confirmar", type: "primary", disabled: false },
+  cancel = { message: "Cancelar", type: "secondary", disabled: false },
+  disableEscapeKeyDown = false
 }) => {
   return (
     <MuiDialog
@@ -21,6 +22,7 @@ const Dialog = ({
       fullWidth
       maxWidth="md"
       className="dialog-container"
+      disableEscapeKeyDown={disableEscapeKeyDown}
     >
       {title && (
         <DialogTitle className="dialog-title">
@@ -36,8 +38,8 @@ const Dialog = ({
         {children}
       </DialogContent>
       <DialogActions className="dialog-actions">
-        <Button onClick={onClose} type={cancel.type} text={cancel.message} />
-        <Button onClick={onConfirm} type={confirm.type} text={confirm.message} />
+        <Button onClick={onClose} type={cancel.type} text={cancel.message} disabled={cancel.disabled} />
+        <Button onClick={onConfirm} type={confirm.type} text={confirm.message} disabled={confirm.disabled} />
       </DialogActions>
     </MuiDialog>
   )

--- a/src/components/Dialog/index.jsx
+++ b/src/components/Dialog/index.jsx
@@ -1,5 +1,5 @@
 import './index.css';
-import { Dialog as MuiDialog, DialogActions, DialogContent, DialogContentText, DialogTitle } from '@mui/material';
+import { Dialog as MuiDialog, DialogActions, DialogContent, DialogContentText, DialogTitle, CircularProgress } from '@mui/material';
 import Button from '../Button';
 
 const Dialog = ({
@@ -11,7 +11,8 @@ const Dialog = ({
   onConfirm,
   confirm = { message: "Confirmar", type: "primary", disabled: false },
   cancel = { message: "Cancelar", type: "secondary", disabled: false },
-  disableEscapeKeyDown = false
+  disableEscapeKeyDown = false,
+  loading = { open: false, message: "" }
 }) => {
   return (
     <MuiDialog
@@ -24,18 +25,27 @@ const Dialog = ({
       className="dialog-container"
       disableEscapeKeyDown={disableEscapeKeyDown}
     >
-      {title && (
-        <DialogTitle className="dialog-title">
-          {title}
-        </DialogTitle>
-      )}
       <DialogContent>
-        {description && (
-          <DialogContentText className="dialog-description" sx={{ mb: 2 }}>
-            {description}
-          </DialogContentText>
+        {loading.open ? (
+          <div className="dialog-loading">
+            <CircularProgress />
+            <p style={{ marginTop: '15px', color: '#666', fontWeight: 'bold' }}>{loading.message}</p>
+          </div>
+        ) : (
+          <>
+            {title && (
+              <DialogTitle className="dialog-title">
+                {title}
+              </DialogTitle>
+            )}
+            {description && (
+              <DialogContentText className="dialog-description" sx={{ mb: 2 }}>
+                {description}
+              </DialogContentText>
+            )}
+            {children}
+          </>
         )}
-        {children}
       </DialogContent>
       <DialogActions className="dialog-actions">
         <Button onClick={onClose} type={cancel.type} text={cancel.message} disabled={cancel.disabled} />

--- a/src/mocks/reponseCancelStripe.js
+++ b/src/mocks/reponseCancelStripe.js
@@ -1,0 +1,189 @@
+const response200 = {
+    "success": true,
+    "customer": "cus_TZi4fmW2W5i8rg",
+    "canceledSubscriptions": [
+        {
+            "id": "sub_1ScYdxRIYLjFPeIa19tLMj7O",
+            "object": "subscription",
+            "application": null,
+            "application_fee_percent": null,
+            "automatic_tax": {
+                "disabled_reason": null,
+                "enabled": false,
+                "liability": null
+            },
+            "billing_cycle_anchor": 1765316425,
+            "billing_cycle_anchor_config": null,
+            "billing_mode": {
+                "flexible": null,
+                "type": "classic"
+            },
+            "billing_thresholds": null,
+            "cancel_at": null,
+            "cancel_at_period_end": false,
+            "canceled_at": 1772589081,
+            "cancellation_details": {
+                "comment": null,
+                "feedback": null,
+                "reason": "cancellation_requested"
+            },
+            "collection_method": "charge_automatically",
+            "created": 1765316425,
+            "currency": "usd",
+            "current_period_end": 1773092425,
+            "current_period_start": 1770673225,
+            "customer": "cus_TZi4fmW2W5i8rg",
+            "customer_account": null,
+            "days_until_due": null,
+            "default_payment_method": "pm_1ScYdwRIYLjFPeIakOroqYhh",
+            "default_source": null,
+            "default_tax_rates": [],
+            "description": null,
+            "discount": null,
+            "discounts": [],
+            "ended_at": 1772589081,
+            "invoice_settings": {
+                "account_tax_ids": null,
+                "issuer": {
+                    "type": "self"
+                }
+            },
+            "items": {
+                "object": "list",
+                "data": [
+                    {
+                        "id": "si_TZi4ZZmFnpfI4L",
+                        "object": "subscription_item",
+                        "billing_thresholds": null,
+                        "created": 1765316425,
+                        "current_period_end": 1773092425,
+                        "current_period_start": 1770673225,
+                        "discounts": [],
+                        "metadata": {},
+                        "plan": {
+                            "id": "price_1ScXq7RIYLjFPeIazfgKKVea",
+                            "object": "plan",
+                            "active": true,
+                            "aggregate_usage": null,
+                            "amount": 200,
+                            "amount_decimal": "200",
+                            "billing_scheme": "per_unit",
+                            "created": 1765313335,
+                            "currency": "usd",
+                            "interval": "month",
+                            "interval_count": 1,
+                            "livemode": true,
+                            "metadata": {},
+                            "meter": null,
+                            "nickname": "Precio de Pruebas con tarjeta real",
+                            "product": "prod_TZhEz2iK3YbZqB",
+                            "tiers_mode": null,
+                            "transform_usage": null,
+                            "trial_period_days": null,
+                            "usage_type": "licensed"
+                        },
+                        "price": {
+                            "id": "price_1ScXq7RIYLjFPeIazfgKKVea",
+                            "object": "price",
+                            "active": true,
+                            "billing_scheme": "per_unit",
+                            "created": 1765313335,
+                            "currency": "usd",
+                            "custom_unit_amount": null,
+                            "livemode": true,
+                            "lookup_key": null,
+                            "metadata": {},
+                            "nickname": "Precio de Pruebas con tarjeta real",
+                            "product": "prod_TZhEz2iK3YbZqB",
+                            "recurring": {
+                                "aggregate_usage": null,
+                                "interval": "month",
+                                "interval_count": 1,
+                                "meter": null,
+                                "trial_period_days": null,
+                                "usage_type": "licensed"
+                            },
+                            "tax_behavior": "unspecified",
+                            "tiers_mode": null,
+                            "transform_quantity": null,
+                            "type": "recurring",
+                            "unit_amount": 200,
+                            "unit_amount_decimal": "200"
+                        },
+                        "quantity": 1,
+                        "subscription": "sub_1ScYdxRIYLjFPeIa19tLMj7O",
+                        "tax_rates": []
+                    }
+                ],
+                "has_more": false,
+                "total_count": 1,
+                "url": "/v1/subscription_items?subscription=sub_1ScYdxRIYLjFPeIa19tLMj7O"
+            },
+            "latest_invoice": "in_1Sz2CqRIYLjFPeIaoAX7KqAI",
+            "livemode": true,
+            "metadata": {},
+            "next_pending_invoice_item_invoice": null,
+            "on_behalf_of": null,
+            "pause_collection": null,
+            "payment_settings": {
+                "payment_method_options": {
+                    "acss_debit": null,
+                    "bancontact": null,
+                    "card": {
+                        "network": null,
+                        "request_three_d_secure": "automatic"
+                    },
+                    "customer_balance": null,
+                    "konbini": null,
+                    "payto": null,
+                    "sepa_debit": null,
+                    "us_bank_account": null
+                },
+                "payment_method_types": [
+                    "card"
+                ],
+                "save_default_payment_method": "off"
+            },
+            "pending_invoice_item_interval": null,
+            "pending_setup_intent": null,
+            "pending_update": null,
+            "plan": {
+                "id": "price_1ScXq7RIYLjFPeIazfgKKVea",
+                "object": "plan",
+                "active": true,
+                "aggregate_usage": null,
+                "amount": 200,
+                "amount_decimal": "200",
+                "billing_scheme": "per_unit",
+                "created": 1765313335,
+                "currency": "usd",
+                "interval": "month",
+                "interval_count": 1,
+                "livemode": true,
+                "metadata": {},
+                "meter": null,
+                "nickname": "Precio de Pruebas con tarjeta real",
+                "product": "prod_TZhEz2iK3YbZqB",
+                "tiers_mode": null,
+                "transform_usage": null,
+                "trial_period_days": null,
+                "usage_type": "licensed"
+            },
+            "quantity": 1,
+            "schedule": null,
+            "start_date": 1765316425,
+            "status": "canceled",
+            "test_clock": null,
+            "transfer_data": null,
+            "trial_end": null,
+            "trial_settings": {
+                "end_behavior": {
+                    "missing_payment_method": "create_invoice"
+                }
+            },
+            "trial_start": null
+        }
+    ]
+};
+
+export { response200 };

--- a/src/mocks/reponseSendFeedback.js
+++ b/src/mocks/reponseSendFeedback.js
@@ -1,0 +1,7 @@
+const response200 = {
+    "error": false,
+    "status": 200,
+    "message": "mensaje enviado"
+};
+
+export { response200 };

--- a/src/services/RequestSvc.jsx
+++ b/src/services/RequestSvc.jsx
@@ -7,105 +7,132 @@ const { NAME_HEADER_AUTH } = require("../utils/Constants");
 const { getStoredValue } = require("./UseLocalStorage");
 
 module.exports = class RequestSvc {
-    /**
-     * Hacer una petición de tipo POST
-     * @param endpoint Endpoint al que se hará la petición
-     * @param payload Datos que se enviarán en la petición
-     * @param header Headers que se desean enviar en la petición
-     * @returns {Promise<{}>}
-     */
-    post = async (endpoint, payload, header = []) => {
-        let headersToRequest = this.createHeaders(header);
-        const requestOptions = {
-            method: 'POST',
-            headers: headersToRequest,
-            redirect: 'follow',
-            body: JSON.stringify(payload)
-        };
-        let requestResponse = await fetch(endpoint, requestOptions);
-        return this.processData(requestResponse);
-    }
+  /**
+   * Hacer una petición de tipo POST
+   * @param endpoint Endpoint al que se hará la petición
+   * @param payload Datos que se enviarán en la petición
+   * @param header Headers que se desean enviar en la petición
+   * @returns {Promise<{}>}
+   */
+  post = async (endpoint, payload, header = []) => {
+    let headersToRequest = this.createHeaders(header);
+    const requestOptions = {
+      method: 'POST',
+      headers: headersToRequest,
+      redirect: 'follow',
+      body: JSON.stringify(payload)
+    };
+    let requestResponse = await fetch(endpoint, requestOptions);
+    return this.processData(requestResponse);
+  }
 
-    /**
-     * Hacer una petición de tipo GET
-     * @param endpoint Endpoint al que se hará la petición
-     * @param header Headers que se desean enviar en la petición
-     * @returns {Promise<{}>}
-     */
-    get = async (endpoint, header = []) => {
-        let headersToRequest = this.createHeaders(header);
-        const requestOptions = {
-            method: 'GET',
-            headers: headersToRequest,
-            redirect: 'follow'
-        };
-        let requestResponse = await fetch(endpoint, requestOptions);
-        return this.processData(requestResponse);
-    }
+  /**
+   * Hacer una petición Mock de tipo POST simulada
+   * @param endpoint Endpoint al que se hará la petición
+   * @param payload Datos que se enviarán en la petición
+   * @param header Headers que se desean enviar en la petición
+   * @returns {Promise<{}>}
+   */
+  postMock = async (endpoint, payload, header = []) => {
+    console.log("MOCK POST call to endpoint:", endpoint, "with payload:", payload);
+    const { response200 } = require("../mocks/reponseSendFeedback");
 
-    /**
-     * Hacer una petición de tipo POST con FormData
-     * @param endpoint Endpoint al que se hará la petición
-     * @param formData FormData que se enviará en la petición
-     * @param header Headers que se desean enviar en la petición
-     * @returns {Promise<{}>}
-     */
-    postFormData = async (endpoint, formData, header = []) => {
-        let headersToRequest = this.createHeaders(header, false); // Don't set Content-Type for FormData
-        const requestOptions = {
-            method: 'POST',
-            headers: headersToRequest,
-            redirect: 'follow',
-            body: formData
-        };
-        let requestResponse = await fetch(endpoint, requestOptions);
-        return this.processData(requestResponse);
-    }
+    return new Promise((resolve) => {
+      setTimeout(() => {
+        // TODO: Se puede cambiar el la peticion
+        // Reponse 200
+        // resolve(response200);
 
-    /**
-     * Crear los headers para el request
-     * @param headers
-     * @param setContentType
-     * @returns {*[]}
-     */
-    createHeaders = (headers = [], setContentType = true) => {
-        let headersToRequest = headers;
-        if (headers.length === 0) {
-            headersToRequest = new Headers();
-        }
-        if (setContentType) {
-            headersToRequest.append("Content-Type", "application/json");
-        }
-        let auth = getStoredValue(NAME_HEADER_AUTH)
-        if (auth) {
-            headersToRequest.append("Authorization", `Bearer ${auth}`);
-        }
-        return headersToRequest;
-    }
+        // Response 500
+        resolve({
+          error: true,
+          status: 500,
+          message: "Error simulado: No se pudo enviar el feedback."
+        });
+      }, 1500);
+    });
+  }
 
-    /**
-     * Procesar la respuesta de cada petición.
-     * @param requestResponse
-     * @returns {Promise<{}>}
-     */
-    processData = async (requestResponse) => {
-        let structResponse = {}
-        try {
-            structResponse.status_code = requestResponse.status
-            let response = await requestResponse.json();
-            if (requestResponse.status !== 200) {
-                let errorStruct = {};
-                errorStruct.code = requestResponse.status;
-                errorStruct.messages = response.msg;
-                throw errorStruct;
-            }
-            structResponse.data = response.data;
-        } catch (err) {
-            structResponse.error = true;
-            structResponse.messages = err.messages ?? 'Unexpected error';
-            structResponse.code = err.code ?? 500;
-            structResponse.status_code = err.code ?? 500;
-        }
-        return structResponse;
+  /**
+   * Hacer una petición de tipo GET
+   * @param endpoint Endpoint al que se hará la petición
+   * @param header Headers que se desean enviar en la petición
+   * @returns {Promise<{}>}
+   */
+  get = async (endpoint, header = []) => {
+    let headersToRequest = this.createHeaders(header);
+    const requestOptions = {
+      method: 'GET',
+      headers: headersToRequest,
+      redirect: 'follow'
+    };
+    let requestResponse = await fetch(endpoint, requestOptions);
+    return this.processData(requestResponse);
+  }
+
+  /**
+   * Hacer una petición de tipo POST con FormData
+   * @param endpoint Endpoint al que se hará la petición
+   * @param formData FormData que se enviará en la petición
+   * @param header Headers que se desean enviar en la petición
+   * @returns {Promise<{}>}
+   */
+  postFormData = async (endpoint, formData, header = []) => {
+    let headersToRequest = this.createHeaders(header, false); // Don't set Content-Type for FormData
+    const requestOptions = {
+      method: 'POST',
+      headers: headersToRequest,
+      redirect: 'follow',
+      body: formData
+    };
+    let requestResponse = await fetch(endpoint, requestOptions);
+    return this.processData(requestResponse);
+  }
+
+  /**
+   * Crear los headers para el request
+   * @param headers
+   * @param setContentType
+   * @returns {*[]}
+   */
+  createHeaders = (headers = [], setContentType = true) => {
+    let headersToRequest = headers;
+    if (headers.length === 0) {
+      headersToRequest = new Headers();
     }
+    if (setContentType) {
+      headersToRequest.append("Content-Type", "application/json");
+    }
+    let auth = getStoredValue(NAME_HEADER_AUTH)
+    if (auth) {
+      headersToRequest.append("Authorization", `Bearer ${auth}`);
+    }
+    return headersToRequest;
+  }
+
+  /**
+   * Procesar la respuesta de cada petición.
+   * @param requestResponse
+   * @returns {Promise<{}>}
+   */
+  processData = async (requestResponse) => {
+    let structResponse = {}
+    try {
+      structResponse.status_code = requestResponse.status
+      let response = await requestResponse.json();
+      if (requestResponse.status !== 200) {
+        let errorStruct = {};
+        errorStruct.code = requestResponse.status;
+        errorStruct.messages = response.msg;
+        throw errorStruct;
+      }
+      structResponse.data = response.data;
+    } catch (err) {
+      structResponse.error = true;
+      structResponse.messages = err.messages ?? 'Unexpected error';
+      structResponse.code = err.code ?? 500;
+      structResponse.status_code = err.code ?? 500;
+    }
+    return structResponse;
+  }
 }

--- a/src/services/StripeSvc.js
+++ b/src/services/StripeSvc.js
@@ -1,0 +1,59 @@
+class StripeSvc {
+  constructor() {
+    if (StripeSvc.instance) {
+      return StripeSvc.instance;
+    }
+    StripeSvc.instance = this;
+  }
+
+  /**
+   * Cancel a user's subscription in Stripe
+   * @param {string} endpoint - The Stripe cancel endpoint
+   * @param {Object} payload - The data to send (e.g. customerID, feedback)
+   */
+  async cancelSubscription(endpoint, payload) {
+    try {
+      const requestOptions = {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(payload)
+      };
+      const response = await fetch(endpoint, requestOptions);
+      const data = await response.json();
+
+      if (!response.ok) {
+        return { error: true, code: response.status, messages: data.msg || data.error || 'Stripe error' };
+      }
+
+      return { status_code: response.status, data: data, error: false };
+    } catch (error) {
+      return { error: true, code: 500, messages: error.message || 'Unexpected error' };
+    }
+  }
+
+  /**
+   * Mock: Cancel a user's subscription in Stripe
+   * simulating a 2-second delay and returning fake success data.
+   */
+  async cancelSubscriptionMock(endpoint, payload) {
+    console.log("MOCK STRIPE call to endpoint:", endpoint, "with payload:", payload);
+    const { response200 } = require("../mocks/reponseCancelStripe");
+
+    return new Promise((resolve) => {
+      setTimeout(() => {
+        // Envolvemos al estilo del wrapper real
+        resolve({
+          status_code: 200,
+          data: response200,
+          error: false
+        });
+      }, 2000); // Simulamos 2 segundos en responder
+    });
+  }
+}
+
+const instance = new StripeSvc();
+
+export default instance;

--- a/src/services/StripeSvc.js
+++ b/src/services/StripeSvc.js
@@ -43,13 +43,21 @@ class StripeSvc {
 
     return new Promise((resolve) => {
       setTimeout(() => {
-        // Envolvemos al estilo del wrapper real
+        // TODO: Se puede cambiar la peticion
+        //Response 200
         resolve({
           status_code: 200,
           data: response200,
           error: false
         });
-      }, 2000); // Simulamos 2 segundos en responder
+
+        // Response 500
+        // resolve({
+        //   error: true,
+        //   code: 500,
+        //   messages: "Error simulado: No se pudo cancelar la suscripción en Stripe."
+        // });
+      }, 2000);
     });
   }
 }

--- a/src/services/StripeSvc.js
+++ b/src/services/StripeSvc.js
@@ -23,7 +23,7 @@ class StripeSvc {
       const response = await fetch(endpoint, requestOptions);
       const data = await response.json();
 
-      if (response?.success !== true) {
+      if (data?.success !== true) {
         return { error: true, messages: data.msg || data.error || 'Stripe error' };
       }
 

--- a/src/services/StripeSvc.js
+++ b/src/services/StripeSvc.js
@@ -23,13 +23,13 @@ class StripeSvc {
       const response = await fetch(endpoint, requestOptions);
       const data = await response.json();
 
-      if (!response.ok) {
-        return { error: true, code: response.status, messages: data.msg || data.error || 'Stripe error' };
+      if (response?.success !== true) {
+        return { error: true, messages: data.msg || data.error || 'Stripe error' };
       }
 
       return { status_code: response.status, data: data, error: false };
     } catch (error) {
-      return { error: true, code: 500, messages: error.message || 'Unexpected error' };
+      return { error: true, messages: error.message || 'Unexpected error' };
     }
   }
 

--- a/src/utils/Constants.jsx
+++ b/src/utils/Constants.jsx
@@ -14,3 +14,6 @@ export const URL_DASHBOARD = `${BASE_URL_FRONT_END}dashboard`;
 export const URL_FUNNELS = `${BASE_URL_FRONT_END}funnels`;
 export const URL_CADEMY = `${BASE_URL_FRONT_END}ghost`;
 export const NAME_HEADER_AUTH = "T-CS";
+const BASE_API_URL_FEEDBACK = 'https://tueducaciondigital.site/'
+export const URL_API_FEEDBACK = `${BASE_API_URL_FEEDBACK}ads/cancel-subscription`;
+export const URL_API_STRIPE_CANCEL = `${BASE_URL_API}hookstest/cancel-subscription-by-email`;

--- a/src/utils/Constants.jsx
+++ b/src/utils/Constants.jsx
@@ -16,4 +16,4 @@ export const URL_CADEMY = `${BASE_URL_FRONT_END}ghost`;
 export const NAME_HEADER_AUTH = "T-CS";
 const BASE_API_URL_FEEDBACK = 'https://tueducaciondigital.site/'
 export const URL_API_FEEDBACK = `${BASE_API_URL_FEEDBACK}ads/cancel-subscription`;
-export const URL_API_STRIPE_CANCEL = `${BASE_URL_API}hookstest/cancel-subscription-by-email`;
+export const URL_API_STRIPE_CANCEL = `${BASE_URL_API}hooks/cancel-subscription-by-email`;

--- a/src/views/ProfilePage/ProfilePage.js
+++ b/src/views/ProfilePage/ProfilePage.js
@@ -156,7 +156,7 @@ const ProfilePage = () => {
 
   const processStripeCancellation = async () => {
     // TODO: Cambiar cancelSubscriptionMock por cancelSubscription
-    return await StripeSvc.cancelSubscriptionMock(URL_API_STRIPE_CANCEL, {
+    return await StripeSvc.cancelSubscription(URL_API_STRIPE_CANCEL, {
       email: user?.Email,
       cancelImmediately: true,
     });

--- a/src/views/ProfilePage/ProfilePage.js
+++ b/src/views/ProfilePage/ProfilePage.js
@@ -1,8 +1,9 @@
 import React, { useEffect, useState, useContext } from "react";
 import "./ProfilePage.css";
 import calendar from "../../assets/calendar.png";
-import { BASE_URL_API } from "../../utils/Constants";
+import { BASE_URL_API, URL_API_FEEDBACK, URL_API_STRIPE_CANCEL } from "../../utils/Constants";
 import RequestSvc from "../../services/RequestSvc";
+import StripeSvc from "../../services/StripeSvc";
 import perfilpic from "../../assets/avatar.jpg";
 import UserContext from '../../UserContext';
 import { Table, TableBody, TableCell, TableContainer, TableHead, TableRow, Paper } from '@mui/material';
@@ -50,11 +51,11 @@ const ProfilePage = () => {
   const [features, setFeatures] = useState([]);
   const [isCancelModalOpen, setIsCancelModalOpen] = useState(false);
   const [cancelReason, setCancelReason] = useState("");
+  const [isProcessingCancel, setIsProcessingCancel] = useState(false);
 
   const getPlanData = async () => {
     let svc = new RequestSvc();
     let result = await svc.get(`${BASE_URL_API}getFeatures/?getPlanDetails=true`).catch((err) => console.log(err));
-    console.log("result is", result)
     if (result.error) {
       alert("No logramos procesar su solicitud");
     }
@@ -91,7 +92,6 @@ const ProfilePage = () => {
     } else {
       let svc = new RequestSvc();
       let result = await svc.post(`${BASE_URL_API}userAccess`, { Password: newPassword }).catch((err) => console.log(err));
-      console.log(result);
       if (result.error) {
         alert("No logramos procesar su solicitud");
       } else {
@@ -110,7 +110,6 @@ const ProfilePage = () => {
     formData.append("Telefono", mobileNumber);
     let svc = new RequestSvc();
     let result = await svc.postFormData(`${BASE_URL_API}userProfile`, formData).catch((err) => console.log(err));
-    console.log(result);
     if (result.error) {
       alert("No logramos procesar su solicitud");
     } else {
@@ -145,11 +144,64 @@ const ProfilePage = () => {
     }
   };
 
-  const handleConfirmCancel = () => {
-    console.log(cancelReason);
-    // window.open('https://help.hotmart.com/es/article/115002183968/-como-cancelar-mi-suscripcion-', '_blank');
+  const sendCancelFeedback = async () => {
+    const requestSvc = new RequestSvc();
+
+    // TODO: Cambiar postMock por post, cambiar userFake por user
+    return await requestSvc.postMock(URL_API_FEEDBACK, {
+      customer_email: userFake.Email,
+      customer_name: `${userFake.Nombre} ${userFake.Apellido}`,
+      body_message: cancelReason
+    });
+  };
+
+  const processStripeCancellation = async () => {
+    // TODO: Cambiar cancelSubscriptionMock por cancelSubscription
+    return await StripeSvc.cancelSubscriptionMock(URL_API_STRIPE_CANCEL, {
+      email: userFake?.Email,
+      cancelImmediately: true,
+    });
+  };
+
+  const finalizeCancellationUI = async () => {
+    alert("Tu suscripción ha sido cancelada exitosamente.");
     setIsCancelModalOpen(false);
-    // setCancelReason("");
+    setCancelReason("");
+    await fetchUserData();
+    setIsProcessingCancel(false);
+  };
+
+  const handleConfirmCancel = async () => {
+    setIsProcessingCancel(true);
+    const messageError = "Ocurrió un error al procesar tu solicitud interna. Por favor, intenta de nuevo.";
+
+    try {
+      const stripeResult = await processStripeCancellation();
+      if (stripeResult.error) {
+        alert(`Ocurrió un error al procesar tu solicitud interna. Por favor, intenta de nuevo.`);
+        return;
+      }
+
+      const feedbackResult = await sendCancelFeedback();
+      if (feedbackResult.error) {
+        alert(messageError);
+        return;
+      }
+
+      await finalizeCancellationUI();
+    } catch (err) {
+      alert(messageError);
+      console.error(err);
+    } finally {
+      setIsProcessingCancel(false);
+    }
+  };
+
+  const handleCloseModal = (e, reason) => {
+    if (!isProcessingCancel) {
+      setIsCancelModalOpen(false);
+      setCancelReason("");
+    }
   };
 
   return (
@@ -402,23 +454,32 @@ const ProfilePage = () => {
       }
       <Dialog
         open={isCancelModalOpen}
-        onClose={() => setIsCancelModalOpen(false)}
+        onClose={(e, reason) => handleCloseModal(e, reason)}
         title="¿Deseas cancelar la suscripción?"
         description="Lamentamos que quieras cancelar tu suscripción. Por favor, cuéntanos el motivo de tu cancelación:"
+        disableEscapeKeyDown={isProcessingCancel}
         onConfirm={() => handleConfirmCancel()}
         confirm={{
           message: "Cancelar suscripción",
-          type: "danger"
+          type: "danger",
+          disabled: isProcessingCancel
         }}
         cancel={{
           message: "Quedarme aquí",
-          type: "secondary-outline"
+          type: "secondary-outline",
+          disabled: isProcessingCancel
+        }}
+        loading={{
+          open: isProcessingCancel,
+          message: "Procesando cancelación..."
         }}
       >
         <textarea
-          placeholder="Escribe aquí..."
+          style={{ width: "100%", padding: "10px", minHeight: "80px", marginTop: "10px", boxSizing: "border-box" }}
+          placeholder="Escribe aquí tu motivo de cancelación..."
           value={cancelReason}
           onChange={(e) => setCancelReason(e.target.value)}
+          disabled={isProcessingCancel}
         />
       </Dialog>
     </div>

--- a/src/views/ProfilePage/ProfilePage.js
+++ b/src/views/ProfilePage/ProfilePage.js
@@ -8,20 +8,21 @@ import UserContext from '../../UserContext';
 import { Table, TableBody, TableCell, TableContainer, TableHead, TableRow, Paper } from '@mui/material';
 import BlockIcon from '@mui/icons-material/Block';
 import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline';
+import Dialog from '../../components/Dialog';
 
 const formatDate = (dateString) => {
   if (!dateString) return '';
-  
+
   const date = new Date(dateString);
   const day = date.getDate().toString().padStart(2, '0');
   const year = date.getFullYear();
-  
+
   const months = [
     'Ene', 'Feb', 'Mar', 'Abr', 'May', 'Jun',
     'Jul', 'Ago', 'Sep', 'Oct', 'Nov', 'Dic'
   ];
   const month = months[date.getMonth()];
-  
+
   return `${day}-${month}-${year}`;
 };
 
@@ -30,11 +31,11 @@ function getRandomNumber() {
   return Math.floor(Math.random() * (8000 - 1000 + 1)) + 1000;
 }
 
-const ProfilePage = () => { 
-  
+const ProfilePage = () => {
+
   const { user, fetchUserData, imageVersion, setImageVersion } = useContext(UserContext);
 
-  
+
   const [iDPersona, setIDPersona] = useState("");
   const [planData, setPlanData] = useState({});
   const [firstName, setFirstName] = useState(user?.Nombre || "");
@@ -47,6 +48,8 @@ const ProfilePage = () => {
   const [selectedFile, setSelectedFile] = useState(null);
   const [loading, setLoading] = useState(false);
   const [features, setFeatures] = useState([]);
+  const [isCancelModalOpen, setIsCancelModalOpen] = useState(false);
+  const [cancelReason, setCancelReason] = useState("");
 
   const getPlanData = async () => {
     let svc = new RequestSvc();
@@ -111,10 +114,10 @@ const ProfilePage = () => {
     if (result.error) {
       alert("No logramos procesar su solicitud");
     } else {
-      
+
       await fetchUserData(); // Refresh user data in context
       alert("Your data has been updated");
-      
+
       // Increment the image version
       setImageVersion((prevVersion) => prevVersion + getRandomNumber());
     }
@@ -142,6 +145,12 @@ const ProfilePage = () => {
     }
   };
 
+  const handleConfirmCancel = () => {
+    console.log(cancelReason);
+    // window.open('https://help.hotmart.com/es/article/115002183968/-como-cancelar-mi-suscripcion-', '_blank');
+    setIsCancelModalOpen(false);
+    // setCancelReason("");
+  };
 
   return (
     <div className="ProfilePage">
@@ -151,7 +160,7 @@ const ProfilePage = () => {
           :
           <div className="inner">
             <h3 className="title">Mi cuenta</h3>
-          
+
             <div className="sectionsContainer">
               <section>
                 <div className="perfilSection">
@@ -159,26 +168,26 @@ const ProfilePage = () => {
                     <h4>Mi perfil</h4>
                     <div className="header">
                       <div className="userImg">
-                      <img
-                        src={
-                          selectedFile
-                            ? URL.createObjectURL(selectedFile)
-                            : user?.Foto 
-                            ? `${user.Foto}?v=${getRandomNumber()}`
-                            : perfilpic
-                        }
-                        alt=""
-                      />
+                        <img
+                          src={
+                            selectedFile
+                              ? URL.createObjectURL(selectedFile)
+                              : user?.Foto
+                                ? `${user.Foto}?v=${getRandomNumber()}`
+                                : perfilpic
+                          }
+                          alt=""
+                        />
                       </div>
                       <div className="userButtons">
                         <input type="file" id="profilePicture" name="profilePicture" accept=".jpg, .jpeg, .png" onChange={handleFileChange} />
-                      <label htmlFor="profilePicture" className="uploadBtn">
-                        Cambiar foto
-                      </label>
+                        <label htmlFor="profilePicture" className="uploadBtn">
+                          Cambiar foto
+                        </label>
                         <br />
-                      <button className="secondBtn" onClick={() => setSelectedFile(null)}>
-                        Eliminar foto
-                      </button>
+                        <button className="secondBtn" onClick={() => setSelectedFile(null)}>
+                          Eliminar foto
+                        </button>
                       </div>
                     </div>
                     <div className="perfilForm">
@@ -305,7 +314,7 @@ const ProfilePage = () => {
                   <div className="planDate">
                     <p>
                       Días para Disfrutar la suscripcion: {planData?.DaysLeft}
-                     
+
                     </p>
                     <p>
                       Próximo cobro: {formatDate(planData?.NextDateCharge)}
@@ -316,21 +325,21 @@ const ProfilePage = () => {
                       <Table>
                         <TableHead>
                           <TableRow>
-                            <TableCell sx={{ 
+                            <TableCell sx={{
                               fontSize: '16px',
                               fontWeight: 'bold'
                             }}>Poderes</TableCell>
-                            <TableCell sx={{ 
+                            <TableCell sx={{
                               fontSize: '16px',
                               textAlign: 'center',
                               fontWeight: 'bold'
                             }}>Has Usado</TableCell>
-                            <TableCell sx={{ 
+                            <TableCell sx={{
                               fontSize: '16px',
                               textAlign: 'center',
                               fontWeight: 'bold'
                             }}>Límite</TableCell>
-                            <TableCell sx={{ 
+                            <TableCell sx={{
                               fontSize: '16px',
                               textAlign: 'center',
                               fontWeight: 'bold'
@@ -341,20 +350,20 @@ const ProfilePage = () => {
                           {features.map((feature) => (
                             <TableRow key={feature.Usuarios_Features_PlanesID}>
                               <TableCell sx={{ fontSize: '16px' }}>{feature.FK_FeaturePlanCode}</TableCell>
-                              <TableCell sx={{ 
+                              <TableCell sx={{
                                 fontSize: '16px',
                                 textAlign: 'center'
                               }}>{feature.TotalUsed}</TableCell>
-                              <TableCell sx={{ 
+                              <TableCell sx={{
                                 fontSize: '16px',
                                 textAlign: 'center'
                               }}>{feature.Limite}</TableCell>
-                              <TableCell sx={{ 
+                              <TableCell sx={{
                                 fontSize: '16px',
                                 textAlign: 'center'
                               }}>
-                                {feature.TotalUsed > feature.Limite ? 
-                                  <BlockIcon color="error" /> : 
+                                {feature.TotalUsed > feature.Limite ?
+                                  <BlockIcon color="error" /> :
                                   <CheckCircleOutlineIcon color="success" />
                                 }
                               </TableCell>
@@ -363,7 +372,7 @@ const ProfilePage = () => {
                         </TableBody>
                       </Table>
                     </TableContainer>
-                    
+
                     {features.some(feature => feature.TotalUsed > feature.Limite) && (
                       <div style={{
                         fontWeight: 'bold',
@@ -378,9 +387,10 @@ const ProfilePage = () => {
                   </div>
                   <div className="planBtn" style={{ marginTop: '20%' }}>
                     <button className="blue">Cambiar plan</button>
-                    <button 
-                      className="red" 
-                      onClick={() => window.open('https://help.hotmart.com/es/article/115002183968/-como-cancelar-mi-suscripcion-', '_blank')}
+                    <button
+                      className="red"
+                      // onClick={() => window.open('https://help.hotmart.com/es/article/115002183968/-como-cancelar-mi-suscripcion-', '_blank')}
+                      onClick={() => setIsCancelModalOpen(true)}
                     >
                       Cancelar suscripción
                     </button>
@@ -390,6 +400,27 @@ const ProfilePage = () => {
             </div>
           </div>
       }
+      <Dialog
+        open={isCancelModalOpen}
+        onClose={() => setIsCancelModalOpen(false)}
+        title="¿Deseas cancelar la suscripción?"
+        description="Lamentamos que quieras cancelar tu suscripción. Por favor, cuéntanos el motivo de tu cancelación:"
+        onConfirm={() => handleConfirmCancel()}
+        confirm={{
+          message: "Cancelar suscripción",
+          type: "danger"
+        }}
+        cancel={{
+          message: "Quedarme aquí",
+          type: "secondary-outline"
+        }}
+      >
+        <textarea
+          placeholder="Escribe aquí..."
+          value={cancelReason}
+          onChange={(e) => setCancelReason(e.target.value)}
+        />
+      </Dialog>
     </div>
   );
 };

--- a/src/views/ProfilePage/ProfilePage.js
+++ b/src/views/ProfilePage/ProfilePage.js
@@ -155,7 +155,6 @@ const ProfilePage = () => {
   };
 
   const processStripeCancellation = async () => {
-    // TODO: Cambiar cancelSubscriptionMock por cancelSubscription
     return await StripeSvc.cancelSubscription(URL_API_STRIPE_CANCEL, {
       email: user?.Email,
       cancelImmediately: true,

--- a/src/views/ProfilePage/ProfilePage.js
+++ b/src/views/ProfilePage/ProfilePage.js
@@ -147,9 +147,9 @@ const ProfilePage = () => {
   const sendCancelFeedback = async () => {
     const requestSvc = new RequestSvc();
 
-    return await requestSvc.postMock(URL_API_FEEDBACK, {
-      customer_email: user.Email,
-      customer_name: `${user.Nombre} ${user.Apellido}`,
+    return await requestSvc.post(URL_API_FEEDBACK, {
+      customer_email: user?.Email,
+      customer_name: `${user?.Nombre} ${user?.Apellido}`,
       body_message: cancelReason
     });
   };
@@ -175,6 +175,7 @@ const ProfilePage = () => {
 
     try {
       const stripeResult = await processStripeCancellation();
+      console.log("stripeResult", stripeResult);
       if (stripeResult.error) {
         alert(`Ocurrió un error al procesar tu solicitud interna. Por favor, intenta de nuevo.`);
         return;

--- a/src/views/ProfilePage/ProfilePage.js
+++ b/src/views/ProfilePage/ProfilePage.js
@@ -147,10 +147,9 @@ const ProfilePage = () => {
   const sendCancelFeedback = async () => {
     const requestSvc = new RequestSvc();
 
-    // TODO: Cambiar postMock por post, cambiar userFake por user
     return await requestSvc.postMock(URL_API_FEEDBACK, {
-      customer_email: userFake.Email,
-      customer_name: `${userFake.Nombre} ${userFake.Apellido}`,
+      customer_email: user.Email,
+      customer_name: `${user.Nombre} ${user.Apellido}`,
       body_message: cancelReason
     });
   };
@@ -158,7 +157,7 @@ const ProfilePage = () => {
   const processStripeCancellation = async () => {
     // TODO: Cambiar cancelSubscriptionMock por cancelSubscription
     return await StripeSvc.cancelSubscriptionMock(URL_API_STRIPE_CANCEL, {
-      email: userFake?.Email,
+      email: user?.Email,
       cancelImmediately: true,
     });
   };


### PR DESCRIPTION
## Descripción del Pull Request

Este PR introduce el flujo completo para que los usuarios puedan cancelar su suscripción directamente desde su página de perfil ([ProfilePage](cci:1://file:///c:/Users/andre/OneDrive/Documentos/PROJECTS/clicspyUserProfile/src/views/ProfilePage/ProfilePage.js:34:0-485:2)). Implementa la recolección de feedback, interacciones seguras de UI durante la petición, y orquesta la comunicación secuencial entre nuestra API interna y la integración con Stripe.

### 🚀 Funcionalidades Principales

- **Modal de Cancelación con Feedback**: Se reemplazó la redirección directa a Hotmart por un modal (Dialog) interactivo que solicita al usuario un motivo (feedback) antes de procesar la cancelación.
- **Flujo de Peticiones Dual**:
  1. Envía el feedback del usuario a `/ads/cancel-subscription`.
  2. Si es exitoso, solicita la cancelación en Stripe vía `/hookstest/cancel-subscription-by-email`.
- **Experiencia de Usuario (UX) Mejorada**:
  - Estado de carga explícito: El `textarea` se reemplaza por un `CircularProgress` con el mensaje *"Procesando cancelación..."*.
  - Desactivación de interacciones: Los botones de Confirmar y Cancelar, así como la tecla `Escape`, se deshabilitan mientras la solicitud está en vuelo para evitar llamadas duplicadas.

### 🛠️ Detalles de Implementación Técnica

- **[src/services/StripeSvc.js](cci:7://file:///c:/Users/andre/OneDrive/Documentos/PROJECTS/clicspyUserProfile/src/services/StripeSvc.js:0:0-0:0)**: Nuevo servicio Singleton aislado para gestionar la comunicación con Stripe.
- **[src/services/RequestSvc.jsx](cci:7://file:///c:/Users/andre/OneDrive/Documentos/PROJECTS/clicspyUserProfile/src/services/RequestSvc.jsx:0:0-0:0) & [StripeSvc](cci:2://file:///c:/Users/andre/OneDrive/Documentos/PROJECTS/clicspyUserProfile/src/services/StripeSvc.js:0:0-62:1)**: Implementación de métodos mock (`postMock`, [cancelSubscriptionMock](cci:1://file:///c:/Users/andre/OneDrive/Documentos/PROJECTS/clicspyUserProfile/src/services/StripeSvc.js:35:2-61:3)) para desarrollo local, soportando tanto resoluciones de éxito (200) simulando respuestas reales como fallos (500).
- **Refactorización de [ProfilePage.js](cci:7://file:///c:/Users/andre/OneDrive/Documentos/PROJECTS/clicspyUserProfile/src/views/ProfilePage/ProfilePage.js:0:0-0:0)**: 
  - La lógica de [handleConfirmCancel](cci:1://file:///c:/Users/andre/OneDrive/Documentos/PROJECTS/clicspyUserProfile/src/views/ProfilePage/ProfilePage.js:172:2-196:4) se dividió en subfunciones más pequeñas ([sendCancelFeedback](cci:1://file:///c:/Users/andre/OneDrive/Documentos/PROJECTS/clicspyUserProfile/src/views/ProfilePage/ProfilePage.js:146:2-154:4), [processStripeCancellation](cci:1://file:///c:/Users/andre/OneDrive/Documentos/PROJECTS/clicspyUserProfile/src/views/ProfilePage/ProfilePage.js:156:2-162:4), [finalizeCancellationUI](cci:1://file:///c:/Users/andre/OneDrive/Documentos/PROJECTS/clicspyUserProfile/src/views/ProfilePage/ProfilePage.js:164:2-170:4)) para mejorar la mantenibilidad y legibilidad empleando promesas (async/await) con manejo estructurado de errores (`try/catch`).
- **Mejoras en Componentes Base (`src/components/`)**:
  - `Dialog`: Soporte extendido para props de `loading`, dependencias de `disableEscapeKeyDown`, y paso de atributos `disabled` a las acciones.
  - `Button`: Estilización de los estados `:disabled` en CSS (cursor `not-allowed`, `opacity: 0.65`) incluyendo soporte JSX para el prop `disabled`.

### 🧪 Pruebas (Mocks Añadidos)

Para facilitar el testeo sin consumir cuotas de API, se añadieron mocks basados en las respuestas reales:
- `src/mocks/reponseCancelStripe.js`: Captura de la respuesta 200 estructural de Stripe.
- `src/mocks/reponseSendFeedback.js`: Simulación de éxito de la API interna.